### PR TITLE
Add auto-collapse when opening other groups

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -30,6 +30,7 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
         val collapseOnHomeFocus =
             activity.findViewById<WdCheckbox>(R.id.collapse_groups_on_home_focus)
 
+
         fun updateCollapseOnHomeVisibility() {
             collapseOnHomeFocus.visibility =
                 if (showGroupHeader.isChecked() && hasCollapsibleGroups.isChecked()) {
@@ -50,6 +51,7 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
             R.id.has_collapsible_groups,
             FileKeys.GROUPS_COLLAPSIBLE,
             false,
+            listOf(R.id.auto_collapse_groups),
             onChange = { updateCollapseOnHomeVisibility() }
         )
         bindWdCheckbox(
@@ -57,6 +59,12 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
             FileKeys.GROUPS_COLLAPSE_ON_HOME_FOCUS,
             false
         )
+
+        val autoCollapseGroups = activity.findViewById<WdCheckbox>(R.id.auto_collapse_groups)
+        autoCollapseGroups.setChecked(prefs.isAutoCollapseGroupsEnabled())
+        autoCollapseGroups.setOnCheckedChangeListener { checked ->
+            prefs.setAutoCollapseGroupsEnabled(checked)
+        }
 
         updateCollapseOnHomeVisibility()
         bindWdCheckbox(R.id.show_year_day, FileKeys.DATE_YEAR_DAY, prefs.isYearDayVisible())

--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsGroupsController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsGroupsController.kt
@@ -20,14 +20,6 @@ class SettingsGroupsController(private val activity: SettingsActivity) {
     fun setup() {
         val container = activity.findViewById<LinearLayout>(R.id.groups)
 
-        val autoCollapseCheckbox = activity.findViewById<com.rama.bohio.widgets.WdCheckbox>(R.id.auto_collapse_groups)
-        autoCollapseCheckbox?.apply {
-            setChecked(prefs.isAutoCollapseGroupsEnabled())
-            setOnCheckedChangeListener { isChecked ->
-                prefs.setAutoCollapseGroupsEnabled(isChecked)
-            }
-        }
-
         fun render() {
             container.removeAllViews()
             groupsManager.getGroupIds().forEach { id ->

--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsGroupsController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsGroupsController.kt
@@ -20,6 +20,14 @@ class SettingsGroupsController(private val activity: SettingsActivity) {
     fun setup() {
         val container = activity.findViewById<LinearLayout>(R.id.groups)
 
+        val autoCollapseCheckbox = activity.findViewById<com.rama.bohio.widgets.WdCheckbox>(R.id.auto_collapse_groups)
+        autoCollapseCheckbox?.apply {
+            setChecked(prefs.isAutoCollapseGroupsEnabled())
+            setOnCheckedChangeListener { isChecked ->
+                prefs.setAutoCollapseGroupsEnabled(isChecked)
+            }
+        }
+
         fun render() {
             container.removeAllViews()
             groupsManager.getGroupIds().forEach { id ->
@@ -35,6 +43,8 @@ class SettingsGroupsController(private val activity: SettingsActivity) {
             render()
         }
     }
+
+    // ------------------- The rest of the class is unchanged -------------------
 
     private fun addGroupRow(groupId: String, groupLabel: String, container: LinearLayout) {
         val row = activity.layoutInflater.inflate(R.layout.list_item_group, container, false)

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -960,6 +960,10 @@ class AppListManager(
                     }
 
                     refresh()
+                    val newPosition = items.indexOfFirst { it is ListItem.Header && it.id == item.id }
+                    if (newPosition != -1) {
+                        layoutManager.scrollToPositionWithOffset(newPosition, offset)
+                    }
                     if (position != RecyclerView.NO_POSITION) {
                         layoutManager.scrollToPositionWithOffset(position, offset)
                     }

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -1053,4 +1053,5 @@ class AppListManager(
         data class App(val info: AppsProvider.AppEntry) : ListItem()
         data object Empty : ListItem()
     }
+    
 }

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -938,12 +938,32 @@ class AppListManager(
         ThemeManager.applyTheme(context, holder.text)
         ViewCompat.setAccessibilityHeading(holder.itemView, true)
         holder.itemView.isFocusable = collapsible
+
         holder.itemView.setOnClickListener(
             if (collapsible) {
                 View.OnClickListener {
                     val position = holder.bindingAdapterPosition
                     val offset = holder.itemView.top - recyclerView.paddingTop
-                    prefs.setGroupExpanded(item.id, !prefs.isGroupExpanded(item.id))
+
+                    val currentlyExpanded = prefs.isGroupExpanded(item.id)
+                    val shouldExpand = !currentlyExpanded
+
+                    // Toggle the clicked group
+                    prefs.setGroupExpanded(item.id, shouldExpand)
+
+                    // If we are expanding and auto‑collapse is on, collapse all other non‑pinned groups
+                    if (shouldExpand && prefs.isAutoCollapseGroupsEnabled()) {
+                        val allGroupIds = getAllGroupIds()
+                        allGroupIds.forEach { otherId ->
+                            if (otherId != item.id &&
+                                !prefs.isGroupKeepExpanded(otherId) &&
+                                prefs.isGroupExpanded(otherId)
+                            ) {
+                                prefs.setGroupExpanded(otherId, false)
+                            }
+                        }
+                    }
+
                     refresh()
                     if (position != RecyclerView.NO_POSITION) {
                         layoutManager.scrollToPositionWithOffset(position, offset)

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -952,16 +952,11 @@ class AppListManager(
                     prefs.setGroupExpanded(item.id, shouldExpand)
 
                     // If we are expanding and auto‑collapse is on, collapse all other non‑pinned groups
-                    if (shouldExpand && prefs.isAutoCollapseGroupsEnabled()) {
-                        val allGroupIds = getAllGroupIds()
-                        allGroupIds.forEach { otherId ->
-                            if (otherId != item.id &&
-                                !prefs.isGroupKeepExpanded(otherId) &&
-                                prefs.isGroupExpanded(otherId)
-                            ) {
-                                prefs.setGroupExpanded(otherId, false)
-                            }
-                        }
+                    val toCollapse = allGroupIds.filter {
+                        it != item.id && !prefs.isGroupKeepExpanded(it) && prefs.isGroupExpanded(it)
+                    }.toSet()
+                    if (toCollapse.isNotEmpty()) {
+                        prefs.setGroupsExpanded(toCollapse, false)
                     }
 
                     refresh()

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -36,8 +36,7 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         const val GROUPS_HEADERS = "groups:headers"
         const val GROUPS_COLLAPSIBLE = "groups:collapsible"
         const val GROUPS_COLLAPSE_ON_HOME_FOCUS = "groups:collapse_on_home_focus"
-
-        const val AUTO_COLLAPSE_GROUPS = "auto_collapse_groups"
+        const val GROUPS_AUTO_COLLAPSE = "auto_collapse_groups"
 
         @Deprecated("Migrated into DATE_FORMAT (see MIGRATION_DATE_FORMAT_RADIO)")
         const val DATE_VISIBLE = "date:visible"
@@ -350,10 +349,10 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         prefs.edit().putInt(FileKeys.GROUP_ORDER(id), value).apply()
 
     fun isAutoCollapseGroupsEnabled(): Boolean =
-        getBoolean(FileKeys.AUTO_COLLAPSE_GROUPS, false)
+        getBoolean(FileKeys.GROUPS_AUTO_COLLAPSE, false)
 
     fun setAutoCollapseGroupsEnabled(enabled: Boolean) {
-        setBoolean(FileKeys.AUTO_COLLAPSE_GROUPS, enabled)
+        setBoolean(FileKeys.GROUPS_AUTO_COLLAPSE, enabled)
     }
 
     fun healData(

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -37,6 +37,8 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         const val GROUPS_COLLAPSIBLE = "groups:collapsible"
         const val GROUPS_COLLAPSE_ON_HOME_FOCUS = "groups:collapse_on_home_focus"
 
+        const val AUTO_COLLAPSE_GROUPS = "auto_collapse_groups"
+
         @Deprecated("Migrated into DATE_FORMAT (see MIGRATION_DATE_FORMAT_RADIO)")
         const val DATE_VISIBLE = "date:visible"
         const val DATE_FORMAT = "date:format"
@@ -88,6 +90,8 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         fun GROUP_EXPANDED(id: String) = "group:$id:expanded"
         fun GROUP_ORDER(id: String) = "group:$id:order"
         fun GROUP_KEEP_EXPANDED(id: String) = "group:$id:keep_expanded"
+
+
     }
 
     object UI {
@@ -344,6 +348,13 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
 
     fun setGroupOrder(id: String, value: Int) =
         prefs.edit().putInt(FileKeys.GROUP_ORDER(id), value).apply()
+
+    fun isAutoCollapseGroupsEnabled(): Boolean =
+        getBoolean(FileKeys.AUTO_COLLAPSE_GROUPS, false)
+
+    fun setAutoCollapseGroupsEnabled(enabled: Boolean) {
+        setBoolean(FileKeys.AUTO_COLLAPSE_GROUPS, enabled)
+    }
 
     fun healData(
         installedApps: List<AppsProvider.AppEntry>,

--- a/app/src/main/res/layout/view_settings.xml
+++ b/app/src/main/res/layout/view_settings.xml
@@ -91,10 +91,10 @@
                     android:text="@string/checkbox_collapse_groups_on_home_focus"
                     style="@style/Checkbox" />
 
-                 <com.rama.bohio.widgets.WdCheckbox
+                <com.rama.bohio.widgets.WdCheckbox
                     android:id="@+id/auto_collapse_groups"
-    		    android:text="@string/auto_collapse_groups_label"
-    		    style="@style/Checkbox" />
+    		        android:text="@string/auto_collapse_groups_label"
+    		        style="@style/Checkbox" />
 
                 <View style="@style/Separator" />
 

--- a/app/src/main/res/layout/view_settings.xml
+++ b/app/src/main/res/layout/view_settings.xml
@@ -91,6 +91,11 @@
                     android:text="@string/checkbox_collapse_groups_on_home_focus"
                     style="@style/Checkbox" />
 
+                 <com.rama.bohio.widgets.WdCheckbox
+                    android:id="@+id/auto_collapse_groups"
+    		    android:text="@string/auto_collapse_groups_label"
+    		    style="@style/Checkbox" />
+
                 <View style="@style/Separator" />
 
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="altdescr_toggle_group_keep_expanded_on">Keep group open when collapsing</string>
     <string name="altdescr_toggle_group_visibility">Toggle group visibility</string>
     <string name="altdescr_toggle_pin_visibility">Toggle PIN visibility</string>
-    <string name="auto_collapse_groups_label">Auto‑collapse groups when opening another</string>
+    <string name="checkbox_auto_collapse_groups">Auto-collapse other groups</string>
     <string name="app_desc">A lightweight, distraction-free Android launcher that’s privacy-first and entirely on-device, designed for focus and simplicity.</string>
     <string name="app_name" translatable="false">@string/product_mako</string>
     <string name="battery_status_power" translatable="false">%1$s %2$dx</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="altdescr_toggle_group_keep_expanded_on">Keep group open when collapsing</string>
     <string name="altdescr_toggle_group_visibility">Toggle group visibility</string>
     <string name="altdescr_toggle_pin_visibility">Toggle PIN visibility</string>
+    <string name="auto_collapse_groups_label">Auto‑collapse groups when opening another</string>
     <string name="app_desc">A lightweight, distraction-free Android launcher that’s privacy-first and entirely on-device, designed for focus and simplicity.</string>
     <string name="app_name" translatable="false">@string/product_mako</string>
     <string name="battery_status_power" translatable="false">%1$s %2$dx</string>


### PR DESCRIPTION
Adds automatic collapsing of other  groups when a new group is opened.
This keeps the UI cleaner by ensuring that only the currently selected group remains expanded.

Tested on Android 16.
samsung A56