### PR TITLE
Add option to move groups to the bottom & fix Auto-collapse bug

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -66,6 +66,8 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
             prefs.setAutoCollapseGroupsEnabled(checked)
         }
 
+        bindWdCheckbox(R.id.groups_position_bottom, FileKeys.GROUPS_POSITION_BOTTOM, false)
+
         updateCollapseOnHomeVisibility()
         bindWdCheckbox(R.id.show_year_day, FileKeys.DATE_YEAR_DAY, prefs.isYearDayVisible())
         bindWdCheckbox(R.id.show_year_week, FileKeys.DATE_YEAR_WEEK, prefs.isYearWeekVisible())

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -97,6 +97,7 @@ class AppListManager(
         if (layoutManager.spanCount != columnCount) {
             layoutManager.spanCount = columnCount
         }
+        layoutManager.reverseLayout = prefs.isGroupsPositionBottom()
         updateAppsCache()
         buildItems()
     }
@@ -139,7 +140,11 @@ class AppListManager(
 
         items.clear()
 
-        getAllGroupIds().forEach { groupId ->
+        val groupIds = getAllGroupIds().let {
+            if (prefs.isGroupsPositionBottom()) it.reversed() else it
+        }
+
+        groupIds.forEach { groupId ->
 
             val apps = groupedMap[groupId] ?: return@forEach
 
@@ -851,6 +856,7 @@ class AppListManager(
 
     private fun configureRecyclerView() {
         layoutManager = GridLayoutManager(context, computeColumnCount())
+        layoutManager.reverseLayout = prefs.isGroupsPositionBottom()
         recyclerView.layoutManager = layoutManager
         recyclerView.adapter = adapter
     }
@@ -948,15 +954,15 @@ class AppListManager(
                     val currentlyExpanded = prefs.isGroupExpanded(item.id)
                     val shouldExpand = !currentlyExpanded
 
-                    // Toggle the clicked group
                     prefs.setGroupExpanded(item.id, shouldExpand)
 
-                    // If we are expanding and auto‑collapse is on, collapse all other non‑pinned groups
-                    val toCollapse = getAllGroupIds().filter {
-                        it != item.id && !prefs.isGroupKeepExpanded(it) && prefs.isGroupExpanded(it)
-                    }.toSet()
-                    if (toCollapse.isNotEmpty()) {
-                        prefs.setGroupsExpanded(toCollapse, false)
+                    if (shouldExpand && prefs.isAutoCollapseGroupsEnabled()) {
+                        val toCollapse = getAllGroupIds().filter {
+                            it != item.id && !prefs.isGroupKeepExpanded(it) && prefs.isGroupExpanded(it)
+                        }.toSet()
+                        if (toCollapse.isNotEmpty()) {
+                            prefs.setGroupsExpanded(toCollapse, false)
+                        }
                     }
 
                     refresh()
@@ -1053,5 +1059,5 @@ class AppListManager(
         data class App(val info: AppsProvider.AppEntry) : ListItem()
         data object Empty : ListItem()
     }
-    
+
 }

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -37,6 +37,7 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         const val GROUPS_COLLAPSIBLE = "groups:collapsible"
         const val GROUPS_COLLAPSE_ON_HOME_FOCUS = "groups:collapse_on_home_focus"
         const val GROUPS_AUTO_COLLAPSE = "auto_collapse_groups"
+        const val GROUPS_POSITION_BOTTOM = "groups:position_bottom"
 
         @Deprecated("Migrated into DATE_FORMAT (see MIGRATION_DATE_FORMAT_RADIO)")
         const val DATE_VISIBLE = "date:visible"
@@ -188,6 +189,7 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         editor.putBoolean(FileKeys.GROUPS_HEADERS, true)
         editor.putBoolean(FileKeys.GROUPS_COLLAPSIBLE, true)
         editor.putBoolean(FileKeys.GROUPS_COLLAPSE_ON_HOME_FOCUS, false)
+        editor.putBoolean(FileKeys.GROUPS_POSITION_BOTTOM, false)
         editor.putBoolean(FileKeys.SECURITY_KEYPAD_RANDOMIZED, true)
         editor.putBoolean(FileKeys.SECURITY_KEYPAD_VISIBLE, false)
 
@@ -485,6 +487,12 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
 
     fun shouldCollapseGroupsOnHomeFocus(): Boolean =
         prefs.getBoolean(FileKeys.GROUPS_COLLAPSE_ON_HOME_FOCUS, false)
+
+    fun isGroupsPositionBottom(): Boolean =
+        prefs.getBoolean(FileKeys.GROUPS_POSITION_BOTTOM, false)
+
+    fun setGroupsPositionBottom(value: Boolean) =
+        prefs.edit().putBoolean(FileKeys.GROUPS_POSITION_BOTTOM, value).apply()
 
     fun getClockFormat(): String =
         prefs.getString(FileKeys.CLOCK_FORMAT, "") ?: ""

--- a/app/src/main/res/layout/view_settings.xml
+++ b/app/src/main/res/layout/view_settings.xml
@@ -96,6 +96,11 @@
     		        android:text="@string/auto_collapse_groups_label"
     		        style="@style/Checkbox" />
 
+                <com.rama.bohio.widgets.WdCheckbox
+                    android:id="@+id/groups_position_bottom"
+                    android:text="@string/checkbox_groups_position_bottom"
+                    style="@style/Checkbox" />
+
                 <View style="@style/Separator" />
 
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,9 +11,9 @@
     <string name="altdescr_toggle_group_keep_expanded_on">Keep group open when collapsing</string>
     <string name="altdescr_toggle_group_visibility">Toggle group visibility</string>
     <string name="altdescr_toggle_pin_visibility">Toggle PIN visibility</string>
+    <string name="auto_collapse_groups_label">Auto-collapse other groups</string>
     <string name="app_desc">A lightweight, distraction-free Android launcher that’s privacy-first and entirely on-device, designed for focus and simplicity.</string>
     <string name="app_name" translatable="false">@string/product_mako</string>
-    <string name="auto_collapse_groups_label">Auto-collapse other groups</string>
     <string name="battery_status_power" translatable="false">%1$s %2$dx</string>
     <string name="battery_status_power_type" translatable="false">%1$s (%2$s) %3$dx</string>
     <string name="battery_temp" translatable="false">%1$d°%2$s</string>
@@ -41,6 +41,7 @@
     <string name="charge_wireless">Wireless</string>
     <string name="checkbox_click_on_icons_open_app_settings">Open app settings when clicking icons</string>
     <string name="checkbox_collapse_groups_on_home_focus">Collapse groups when returning home</string>
+    <string name="checkbox_groups_position_bottom">Show groups at the bottom of the screen</string>
     <string name="checkbox_has_collapsible_groups">Allow collapsing groups</string>
     <string name="checkbox_include_hidden_in_search">Include hidden groups in search</string>
     <string name="checkbox_lock_settings">Lock Settings</string>


### PR DESCRIPTION
Add a option to move the groups to the bottom of the screen.
the list of app's in this mode open toward  up.
this make easy for one hand use.

This also fix Auto-collapse bug when Disabling Auto-collapse