### PR TITLE
do not use FLAG_ACTIVITY_CLEAR_TASK in checkbox.setOnCheckedChangeListener

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsAppearanceController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsAppearanceController.kt
@@ -265,13 +265,6 @@ class SettingsAppearanceController(private val activity: SettingsActivity) {
                 if (isChecked) PrefsManager.BackgroundMode.WALLPAPER else PrefsManager.BackgroundMode.DEFAULT
             prefs.setHomeBackgroundMode(mode)
             activity.applySettingsBackground()
-            if (isChecked) {
-                activity.startActivity(
-                    Intent(activity, MainActivity::class.java).apply {
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                    }
-                )
-            }
         }
     }
 


### PR DESCRIPTION
The FLAG _ACTIVITY_ CLEAR_TASK is a nuclear option.
it's wipes the entire back stack, including the Settings screen that the user standing on.
So the moment the user flipped the checkbox, the app deleted Settings and rebuilt the home screen from scratch just to make it notice the new wallpaper setting.
MainActivity already had code that re-check the wallpaper setting and redraw accordingly, it's in onResume() & applyHomeBackground() logic.
So the app already knew how to refresh itself naturally.